### PR TITLE
translate: market

### DIFF
--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -4,12 +4,13 @@ import simTab from './simTab'
 import tutorialMenu from './tutorialMenu'
 import room from './room'
 import tutorial from './tutorial'
-
+import market from './market'
 export default [
     overview,
     sidebar,
     simTab,
     tutorialMenu,
     ...tutorial,
-    room
+    room,
+    ...market
 ]

--- a/src/pages/market/index.ts
+++ b/src/pages/market/index.ts
@@ -1,0 +1,6 @@
+import marketMenu from './marketMenu'
+import marketAll from './marketAll'
+import marketMy from './marketMy'
+import marketHistory from './marketHistory'
+
+export default [marketMenu,marketAll,marketMy,marketHistory]

--- a/src/pages/market/marketAll.ts
+++ b/src/pages/market/marketAll.ts
@@ -1,0 +1,43 @@
+const content: PageContent = {
+    hashs: ['#!/market/all'],
+    content: [
+        // 市场->全部订单
+        { 'en-US': 'Raw resources', 'zh-CN': '原始资源' },
+        { 'en-US': 'Factory production', 'zh-CN': '工厂产物' },
+        { 'en-US': 'Lab production', 'zh-CN': '实验室产物' },
+        // 订单明细
+        { 'en-US': 'Refresh', 'zh-CN': '刷新' },
+        { 'en-US': 'Target room:', 'zh-CN': '目标房间' },
+        { 'en-US': 'Selling', 'zh-CN': '出售中' },
+        { 'en-US': 'Buying', 'zh-CN': '求购中' },
+        { 'en-US': 'Order ID', 'zh-CN': '订单标识', 'reuse': true },
+        { 'en-US': 'Price', 'zh-CN': '单价', 'reuse': true },
+        { 'en-US': 'Available', 'zh-CN': '可用', 'reuse': true },
+        { 'en-US': 'Remaining', 'zh-CN': '剩余', 'reuse': true },
+        { 'en-US': 'Total', 'zh-CN': '总量', 'reuse': true },
+        { 'en-US': 'Room', 'zh-CN': '房间', 'reuse': true },
+        { 'en-US': 'Range', 'zh-CN': '范围', 'reuse': true },
+        { 'en-US': 'Price history', 'zh-CN': '历史单价' },
+        { 'en-US': 'Date', 'zh-CN': '日期' },
+        { 'en-US': 'Transactions', 'zh-CN': '交易次数' },
+        { 'en-US': 'Total volume', 'zh-CN': '总成交量' },
+        { 'en-US': 'Price (avg ± stddev)', 'zh-CN': '单价 (均价 ± 标准差)' },
+        
+        // 翻译订单
+        {
+            'selector': '#mat-dialog-0 > app-dlg-resource-orders > header:nth-child(6) > div:nth-child(1) > span',
+            'zh-CN': (el: HTMLElement) => {
+                el.innerHTML = el.innerHTML.replace('orders', '个订单')
+            }
+        },
+        {
+            'selector': '#mat-dialog-0 > app-dlg-resource-orders > header:nth-child(8) > div > span',
+            'zh-CN': (el: HTMLElement) => {
+                el.innerHTML = el.innerHTML.replace('orders', '个订单')
+            }
+        }
+        
+    ]
+}
+
+export default content

--- a/src/pages/market/marketHistory.ts
+++ b/src/pages/market/marketHistory.ts
@@ -1,0 +1,39 @@
+const content: PageContent = {
+    hashs: ['#!/market/history'],
+    content: [
+        // 市场->订单历史
+        // 表头
+        { 'en-US': 'Expand all', 'zh-CN': '展开全部' },
+        { 'en-US': 'Refresh', 'zh-CN': '刷新' },
+        { 'en-US': 'Date', 'zh-CN': '成交时间' ,'reuse': true},
+        { 'en-US': 'Shard', 'zh-CN': '位面' ,'reuse': true},
+        { 'en-US': 'Tick', 'zh-CN': '时刻' ,'reuse': true},
+        { 'en-US': 'Change', 'zh-CN': '成交金额' ,'reuse': true},
+        { 'en-US': 'Balance', 'zh-CN': '余额' ,'reuse': true},
+        { 'en-US': 'Description', 'zh-CN': '描述' ,'reuse': true},
+
+        // 明细
+        { 'en-US': 'Resources', 'zh-CN': '资源' ,'reuse': true},
+        { 'en-US': 'Owner', 'zh-CN': '原资源拥有人' ,'reuse': true},
+        { 'en-US': 'Dealer', 'zh-CN': '成交人' ,'reuse': true},
+        { 'en-US': 'Fee type', 'zh-CN': '费用类型' ,'reuse': true},
+        { 'en-US': 'Add amount', 'zh-CN': '订单量增加' ,'reuse': true},
+        { 'en-US': 'Order ID', 'zh-CN': '订单标识' ,'reuse': true},
+        { 'en-US': 'Price', 'zh-CN': '单价' ,'reuse': true},
+
+        // 费用类型
+        { 'en-US': 'Extend order', 'zh-CN': '扩充订单' ,'reuse': true},
+        { 'en-US': 'Change price', 'zh-CN': '变更单价' ,'reuse': true},
+        
+        // 描述类
+        { 'en-US': 'Market fee', 'zh-CN': '市场费用' ,'reuse': true},
+        { 'en-US': 'Resources sold via market order', 'zh-CN': '通过市场订单卖出资源' ,'reuse': true},
+        { 'en-US': 'Resources bought via market order', 'zh-CN': '通过市场订单买入资源' ,'reuse': true},
+        
+        // 页尾
+        { 'en-US': 'Newer', 'zh-CN': '更早的记录' },
+        { 'en-US': 'Older', 'zh-CN': '更晚的记录' }
+    ]
+}
+
+export default content

--- a/src/pages/market/marketMenu.ts
+++ b/src/pages/market/marketMenu.ts
@@ -1,0 +1,13 @@
+const content: PageContent = {
+    hashs: ['#!/market/all','#!/market/my','#!/market/history'],
+    content: [
+        // 市场 header 部分
+        { 'en-US': 'Market allows to automatically trade resources with other players.', 'zh-CN': '市场允许你和其他玩家自动交易资源。' },
+        { 'en-US': 'Learn more', 'zh-CN': '了解更多' },
+        { 'en-US': 'All orders', 'zh-CN': '全部订单' },
+        { 'en-US': 'My orders', 'zh-CN': '我的订单' },
+        { 'en-US': 'History', 'zh-CN': '订单历史' },
+    ]
+}
+
+export default content

--- a/src/pages/market/marketMy.ts
+++ b/src/pages/market/marketMy.ts
@@ -1,0 +1,19 @@
+const content: PageContent = {
+    hashs: ['#!/market/my'],
+    content: [
+        // 市场->我的订单
+        { 'en-US': 'Refresh', 'zh-CN': '刷新' },
+        { 'en-US': 'Order ID', 'zh-CN': '订单标识' },
+        { 'en-US': 'Type', 'zh-CN': '类型' },
+        { 'en-US': 'Active', 'zh-CN': '激活' },
+        { 'en-US': 'Price', 'zh-CN': '单价' },
+        { 'en-US': 'Available', 'zh-CN': '可用' },
+        { 'en-US': 'Remaining', 'zh-CN': '剩余' },
+        { 'en-US': 'Total', 'zh-CN': '总量' },
+        { 'en-US': 'Room', 'zh-CN': '房间' },
+        { 'en-US': 'Expires in', 'zh-CN': '过期于' }
+        
+    ]
+}
+
+export default content


### PR DESCRIPTION
翻译了 market/all, market/my, market/history 三个页面的除资源名称外的内容